### PR TITLE
Fix issue #8 (and its subissues #9, #10, #11)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "coordinate-derive"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "proc-macro-crate",
  "quote",
@@ -541,7 +541,7 @@ checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "genome"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -600,7 +600,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "grups-io"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "grups-rs"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -900,7 +900,7 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "located-error"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "thiserror",
@@ -924,7 +924,7 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "logger"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "env_logger",
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "parser"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1216,7 +1216,7 @@ dependencies = [
 
 [[package]]
 name = "pedigree_sims"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "pwd_from_stdin"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1851,7 +1851,7 @@ checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "vcf-fst"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "fst",
  "genome",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-  version           = "0.5.0"
+  version           = "0.5.1"
   authors           = ["Maël Lefeuvre <mael.lefeuvre@mnhn.fr>"]
   description       = "GRUPS-rs: Get Relatedness Using Pedigree Simulations"
   edition           = "2021"

--- a/src/genome/src/sex/mod.rs
+++ b/src/genome/src/sex/mod.rs
@@ -12,6 +12,14 @@ impl Sex {
     pub fn random() -> Self {
         [Self::Female, Self::Male][usize::from(fastrand::bool())]
     }
+
+    #[must_use]
+    pub fn is_unknown(&self) -> bool {
+        match self {
+            Self::Unknown => true,
+            _             => false,
+        }
+    }
 }
 
 impl FromStr for Sex {
@@ -19,7 +27,7 @@ impl FromStr for Sex {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s.to_lowercase().as_str() {
-            "male" | "1"   => Self::Male,
+            "male"   | "1" => Self::Male,
             "female" | "2" => Self::Female,
             _              => Self::Unknown,
         })

--- a/src/genome/src/snp/allele/error.rs
+++ b/src/genome/src/snp/allele/error.rs
@@ -1,5 +1,11 @@
 use thiserror::Error;
 
-#[derive(Error, Debug)]
-#[error("Failed to parse allele into a valid character")]
-pub struct ParseAlleleError;
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum ParseAlleleError {
+
+    #[error("Failed to parse character into a valid Allele")]
+    InvalidCharacter,
+    
+    #[error("Failed to parse IUPAC Ambiguity code into a valid Allele.")]
+    IUPACAmbiguityCodeCharacterFound
+}

--- a/src/genome/src/snp/allele/mod.rs
+++ b/src/genome/src/snp/allele/mod.rs
@@ -34,7 +34,8 @@ impl TryFrom<char> for Allele {
             'T'       => Ok(T),
             'N'       => Ok(N),
             '*'       => Ok(D),
-             _  => Err(ParseAlleleError)
+            'R' | 'Y' | 'S' | 'W' | 'K' | 'M' | 'B' | 'D' | 'H' | 'V' => Err(ParseAlleleError::IUPACAmbiguityCodeCharacterFound),
+             _  => Err(ParseAlleleError::InvalidCharacter)
         }
     }
 }
@@ -43,7 +44,7 @@ impl FromStr for Allele {
     type Err = ParseAlleleError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let char = s.parse::<char>().map_err(|_| ParseAlleleError)?;
+        let char = s.parse::<char>().map_err(|_| ParseAlleleError::InvalidCharacter)?;
         Self::try_from(char)
     }
 }
@@ -107,7 +108,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "Not a valid allele character: ParseAlleleError"]
+    #[should_panic = "Not a valid allele character: InvalidCharacter"]
     fn panic_try_from_char_panic() {
         Allele::try_from('x').expect("Not a valid allele character");
     }
@@ -126,6 +127,15 @@ mod tests {
                 Allele::A | Allele::C | Allele::G | Allele::T => true,
                 Allele::D | Allele::N                         => false
             });
+        }
+    }
+
+    #[test]
+    fn detect_iupac() {
+        const IUPAC_CHARS: [char; 10] = ['R', 'Y', 'S', 'W', 'K', 'M', 'B', 'D', 'H', 'V'];
+        for allele_char in IUPAC_CHARS {
+            let allele = Allele::try_from(allele_char);
+            assert!(allele.is_err_and(|e| e == ParseAlleleError::IUPACAmbiguityCodeCharacterFound))
         }
     }
 }

--- a/src/grups-io/src/read/panel_reader/error.rs
+++ b/src/grups-io/src/read/panel_reader/error.rs
@@ -19,6 +19,18 @@ pub enum PanelReaderError {
     MissingSample(String),
 
     #[error("Exhausted the number of available samples to populate the pedigree")]
-    ExhaustedPanel
+    ExhaustedPanel,
+
+    #[error("Line {0} of the provided .panel definition file does not contain the appropriate number of fields. Each line of this file should contain 3 to 4 fields: <ID (required)> <super-population-tag (required)> <population tag (required)> <sex (optional)> (e.g. 'HG00096 GBR EUR male')")]
+    InvalidNumberOfFields(usize),
+
+    #[error("Line {0} - Field 1 of the provided .panel definition file carries an invalid Individual-ID.")]
+    ParseIndividualId(usize),
+
+    #[error("Line {0} - Field 2 of the provided .panel definition file carries an invalid Superpopulation ID.")]
+    ParseSuperPop(usize),
+
+    #[error("Line {0} - Field 3 of the provided .panel definition file carries an invalid Population ID.")]
+    ParsePop(usize),
 
 }

--- a/src/vcf-fst/src/lib.rs
+++ b/src/vcf-fst/src/lib.rs
@@ -378,7 +378,7 @@ impl<'a, 'panel> VCFIndexer<'a, 'panel> {
         let mut frequencies : BTreeMap<&str, f32> = BTreeMap::new();
         
         let pop_afs: Option<Vec<(&str, &str)>> = info.iter()
-            .filter(|&field| field.contains("_AF"))
+            .filter(|&field| field.contains("_AF="))
             .map(|field| field.split_once("_AF="))
             .collect();
 


### PR DESCRIPTION
This PR adresses issue #8, and subissues #9, #10, #11 .

## Bugfixes:
* Closes issue #8
* Closes subissue #9
* Closes subissue #10
* Closes subissue #11

## Changes: 
* Program now emits a warning to the user when encountering IUPAC ambiguity characters, and automatically converts them to `Allele::N`
* `PanelReader` is now much less dumb and can handle empty lines, and perform legible error reporting to the user
* `fst` Module now searches for the pattern '_AF=' instead of '_AF'. This workaround is far from perfect, but hopefully strikes a good balance between performance and stringency.
